### PR TITLE
Fix stories not being listed when storybook is iframed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ export class PostmsgTransport {
       }
       return iframe.contentWindow;
     }
-    return window.top;
+    return window.parent;
   }
 
   _handleEvent(e) {


### PR DESCRIPTION
When storybook is iframed, `window.top` refers to the topmost window. Changing to `window.parent` ensured that the channel only goes one level up. Might not be perfect, but fixes the issue for now.